### PR TITLE
Fixed recipes for 1.21.2+

### DIFF
--- a/src/main/resources/data/beautify/recipe/acacia_blinds.json
+++ b/src/main/resources/data/beautify/recipe/acacia_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:acacia_slab"
-        }
-    },
-    "result": {
-        "id": "beautify:acacia_blinds",
-        "count": 1
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:acacia_slab"
+  },
+  "result": {
+    "id": "beautify:acacia_blinds",
+    "count": 1
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/acacia_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/acacia_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:acacia_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:acacia_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:acacia_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:acacia_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/acacia_trellis.json
+++ b/src/main/resources/data/beautify/recipe/acacia_trellis.json
@@ -1,21 +1,17 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/ /",
-        " O ",
-        "/ /"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "O": {
-            "item": "minecraft:acacia_log"
-        }
-    },
-    "result": {
-        "id": "beautify:acacia_trellis",
-        "count": 4
-    },
-    "group": "trellis"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " O ",
+    "/ /"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "O": "minecraft:acacia_log"
+  },
+  "result": {
+    "id": "beautify:acacia_trellis",
+    "count": 4
+  },
+  "group": "trellis"
 }

--- a/src/main/resources/data/beautify/recipe/birch_blinds.json
+++ b/src/main/resources/data/beautify/recipe/birch_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:birch_slab"
-        }
-    },
-    "result": {
-        "id": "beautify:birch_blinds",
-        "count": 1
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:birch_slab"
+  },
+  "result": {
+    "id": "beautify:birch_blinds",
+    "count": 1
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/birch_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/birch_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:birch_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:birch_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:birch_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:birch_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/birch_trellis.json
+++ b/src/main/resources/data/beautify/recipe/birch_trellis.json
@@ -1,21 +1,17 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/ /",
-        " O ",
-        "/ /"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "O": {
-            "item": "minecraft:birch_log"
-        }
-    },
-    "result": {
-        "id": "beautify:birch_trellis",
-        "count": 4
-    },
-    "group": "trellis"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " O ",
+    "/ /"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "O": "minecraft:birch_log"
+  },
+  "result": {
+    "id": "beautify:birch_trellis",
+    "count": 4
+  },
+  "group": "trellis"
 }

--- a/src/main/resources/data/beautify/recipe/bookstack.json
+++ b/src/main/resources/data/beautify/recipe/bookstack.json
@@ -1,18 +1,12 @@
 {
-	"type": "minecraft:crafting_shapeless",
-	"ingredients": [
-		{
-			"item": "minecraft:book"
-		},
-		{
-			"item": "minecraft:book"
-		},
-		{
-			"item": "minecraft:book"
-		}
-	],
-	"result": {
-		"id": "beautify:bookstack",
-		"count": 1
-	}
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    "minecraft:book",
+    "minecraft:book",
+    "minecraft:book"
+  ],
+  "result": {
+    "id": "beautify:bookstack",
+    "count": 1
+  }
 }

--- a/src/main/resources/data/beautify/recipe/botanist_workbench.json
+++ b/src/main/resources/data/beautify/recipe/botanist_workbench.json
@@ -5,14 +5,8 @@
         "PP"
     ],
     "key": {
-        "#": {
-            "item": "minecraft:flower_pot"
-        },
-        "P": [
-            {
-                "tag": "minecraft:planks"
-            }
-        ]
+        "#": "minecraft:flower_pot",
+        "P": "#minecraft:planks"
     },
     "result": {
         "id": "beautify:botanist_workbench",

--- a/src/main/resources/data/beautify/recipe/candelabra.json
+++ b/src/main/resources/data/beautify/recipe/candelabra.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_black.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_black.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:black_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_black",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:black_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_black",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_blue.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_blue.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:blue_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_blue",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:blue_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_blue",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_brown.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_brown.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:brown_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_brown",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:brown_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_brown",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_cyan.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_cyan.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:cyan_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_cyan",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:cyan_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_cyan",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_gray.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_gray.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:gray_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_gray",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:gray_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_gray",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_green.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_green.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:green_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_green",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:green_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_green",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_light_blue.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_light_blue.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:light_blue_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_light_blue",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:light_blue_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_light_blue",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_light_gray.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_light_gray.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:light_gray_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_light_gray",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:light_gray_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_light_gray",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_lime.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_lime.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:lime_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_lime",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:lime_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_lime",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_magenta.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_magenta.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:magenta_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_magenta",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:magenta_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_magenta",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_orange.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_orange.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:orange_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_orange",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:orange_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_orange",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_pink.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_pink.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:pink_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_pink",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:pink_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_pink",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_purple.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_purple.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:purple_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_purple",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:purple_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_purple",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_red.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_red.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:red_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_red",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:red_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_red",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_white.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_white.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:white_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_white",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:white_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_white",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/candelabra_yellow.json
+++ b/src/main/resources/data/beautify/recipe/candelabra_yellow.json
@@ -1,21 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"###",
-		"III",
-		" I "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:yellow_candle"
-		},
-		"I": {
-			"item": "minecraft:iron_nugget"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_candelabra_yellow",
-		"count": 1
-	},
-	"group": "candelabras"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "III",
+    " I "
+  ],
+  "key": {
+    "#": "minecraft:yellow_candle",
+    "I": "minecraft:iron_nugget"
+  },
+  "result": {
+    "id": "beautify:lamp_candelabra_yellow",
+    "count": 1
+  },
+  "group": "candelabras"
 }

--- a/src/main/resources/data/beautify/recipe/cherry_blinds.json
+++ b/src/main/resources/data/beautify/recipe/cherry_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:cherry_slab"
-        }
-    },
-    "result": {
-        "id": "beautify:cherry_blinds",
-        "count": 1
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:cherry_slab"
+  },
+  "result": {
+    "id": "beautify:cherry_blinds",
+    "count": 1
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/cherry_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/cherry_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:cherry_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:cherry_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:cherry_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:cherry_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/cherry_trellis.json
+++ b/src/main/resources/data/beautify/recipe/cherry_trellis.json
@@ -1,21 +1,17 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/ /",
-        " O ",
-        "/ /"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "O": {
-            "item": "minecraft:cherry_log"
-        }
-    },
-    "result": {
-        "id": "beautify:cherry_trellis",
-        "count": 4
-    },
-    "group": "trellis"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " O ",
+    "/ /"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "O": "minecraft:cherry_log"
+  },
+  "result": {
+    "id": "beautify:cherry_trellis",
+    "count": 4
+  },
+  "group": "trellis"
 }

--- a/src/main/resources/data/beautify/recipe/crimson_blinds.json
+++ b/src/main/resources/data/beautify/recipe/crimson_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:crimson_slab"
-        }
-    },
-    "result": {
-        "id": "beautify:crimson_blinds",
-        "count": 1
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:crimson_slab"
+  },
+  "result": {
+    "id": "beautify:crimson_blinds",
+    "count": 1
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/crimson_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/crimson_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:crimson_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:crimson_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:crimson_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:crimson_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/crimson_trellis.json
+++ b/src/main/resources/data/beautify/recipe/crimson_trellis.json
@@ -1,21 +1,17 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/ /",
-        " O ",
-        "/ /"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "O": {
-            "item": "minecraft:crimson_stem"
-        }
-    },
-    "result": {
-        "id": "beautify:crimson_trellis",
-        "count": 4
-    },
-    "group": "trellis"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " O ",
+    "/ /"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "O": "minecraft:crimson_stem"
+  },
+  "result": {
+    "id": "beautify:crimson_trellis",
+    "count": 4
+  },
+  "group": "trellis"
 }

--- a/src/main/resources/data/beautify/recipe/dark_oak_blinds.json
+++ b/src/main/resources/data/beautify/recipe/dark_oak_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:dark_oak_slab"
-        }
-    },
-    "result": {
-        "id": "beautify:dark_oak_blinds",
-        "count": 1
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:dark_oak_slab"
+  },
+  "result": {
+    "id": "beautify:dark_oak_blinds",
+    "count": 1
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/dark_oak_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/dark_oak_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:dark_oak_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:dark_oak_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:dark_oak_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:dark_oak_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/dark_oak_trellis.json
+++ b/src/main/resources/data/beautify/recipe/dark_oak_trellis.json
@@ -1,21 +1,17 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/ /",
-        " O ",
-        "/ /"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "O": {
-            "item": "minecraft:dark_oak_log"
-        }
-    },
-    "result": {
-        "id": "beautify:dark_oak_trellis",
-        "count": 4
-    },
-    "group": "trellis"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " O ",
+    "/ /"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "O": "minecraft:dark_oak_log"
+  },
+  "result": {
+    "id": "beautify:dark_oak_trellis",
+    "count": 4
+  },
+  "group": "trellis"
 }

--- a/src/main/resources/data/beautify/recipe/from_iron_blinds.json
+++ b/src/main/resources/data/beautify/recipe/from_iron_blinds.json
@@ -1,12 +1,12 @@
 {
-    "type": "minecraft:smelting",
-    "category": "blocks",
-    "ingredient": {
-        "item": "beautify:iron_blinds"
-    },
-    "result": {
-        "id": "minecraft:iron_ingot"
-    },
-    "experience": 0.1,
-    "cookingtime": 250
+  "type": "minecraft:smelting",
+  "category": "blocks",
+  "ingredient": {
+    "item": "beautify:iron_blinds"
+  },
+  "result": {
+    "id": "minecraft:iron_ingot"
+  },
+  "experience": 0.1,
+  "cookingtime": 250
 }

--- a/src/main/resources/data/beautify/recipe/hanging_pot.json
+++ b/src/main/resources/data/beautify/recipe/hanging_pot.json
@@ -1,20 +1,16 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		"#",
-		"F"
-	],
-	"key": {
-		"#": {
-			"item": "beautify:rope"
-		},
-		"F": {
-			"item": "minecraft:flower_pot"
-		}
-	},
-	"result": {
-		"id": "beautify:hanging_pot",
-		"count": 1
-	},
-	"group": "hanging_pot"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "F"
+  ],
+  "key": {
+    "#": "beautify:rope",
+    "F": "minecraft:flower_pot"
+  },
+  "result": {
+    "id": "beautify:hanging_pot",
+    "count": 1
+  },
+  "group": "hanging_pot"
 }

--- a/src/main/resources/data/beautify/recipe/iron_blinds.json
+++ b/src/main/resources/data/beautify/recipe/iron_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:iron_ingot"
-        }
-    },
-    "result": {
-        "id": "beautify:iron_blinds",
-        "count": 2
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:iron_ingot"
+  },
+  "result": {
+    "id": "beautify:iron_blinds",
+    "count": 2
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/jungle_blinds.json
+++ b/src/main/resources/data/beautify/recipe/jungle_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:jungle_slab"
-        }
-    },
-    "result": {
-        "id": "beautify:jungle_blinds",
-        "count": 1
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:jungle_slab"
+  },
+  "result": {
+    "id": "beautify:jungle_blinds",
+    "count": 1
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/jungle_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/jungle_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:jungle_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:jungle_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:jungle_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:jungle_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/jungle_trellis.json
+++ b/src/main/resources/data/beautify/recipe/jungle_trellis.json
@@ -1,21 +1,17 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/ /",
-        " O ",
-        "/ /"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "O": {
-            "item": "minecraft:jungle_log"
-        }
-    },
-    "result": {
-        "id": "beautify:jungle_trellis",
-        "count": 4
-    },
-    "group": "trellis"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " O ",
+    "/ /"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "O": "minecraft:jungle_log"
+  },
+  "result": {
+    "id": "beautify:jungle_trellis",
+    "count": 4
+  },
+  "group": "trellis"
 }

--- a/src/main/resources/data/beautify/recipe/lamp_bamboo.json
+++ b/src/main/resources/data/beautify/recipe/lamp_bamboo.json
@@ -1,23 +1,17 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" # ",
-		"ScS",
-		" # "
-	],
-	"key": {
-		"#": {
-			"item": "minecraft:bamboo"
-		},
-		"S": {
-			"item": "minecraft:string"
-		},
-		"c": {
-			"item": "minecraft:copper_ingot"
-		}
-	},
-	"result": {
-		"id": "beautify:lamp_bamboo",
-		"count": 1
-	}
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " # ",
+    "ScS",
+    " # "
+  ],
+  "key": {
+    "#": "minecraft:bamboo",
+    "S": "minecraft:string",
+    "c": "minecraft:copper_ingot"
+  },
+  "result": {
+    "id": "beautify:lamp_bamboo",
+    "count": 1
+  }
 }

--- a/src/main/resources/data/beautify/recipe/lamp_jar.json
+++ b/src/main/resources/data/beautify/recipe/lamp_jar.json
@@ -1,15 +1,11 @@
 {
-    "type": "minecraft:crafting_shapeless",
-    "ingredients": [
-        {
-            "item": "minecraft:glowstone_dust"
-        },
-        {
-            "item": "minecraft:glass_bottle"
-        }
-    ],
-    "result": {
-        "id": "beautify:lamp_jar",
-        "count": 1
-    }
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    "minecraft:glowstone_dust",
+    "minecraft:glass_bottle"
+  ],
+  "result": {
+    "id": "beautify:lamp_jar",
+    "count": 1
+  }
 }

--- a/src/main/resources/data/beautify/recipe/lamp_light_bulb.json
+++ b/src/main/resources/data/beautify/recipe/lamp_light_bulb.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        " # ",
-        "#c#",
-        " # "
-    ],
-    "key": {
-        "#": {
-            "item": "minecraft:glass_pane"
-        },
-        "c": {
-            "item": "minecraft:copper_ingot"
-        }
-    },
-    "result": {
-        "id": "beautify:lamp_light_bulb",
-        "count": 1
-    }
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " # ",
+    "#c#",
+    " # "
+  ],
+  "key": {
+    "#": "minecraft:glass_pane",
+    "c": "minecraft:copper_ingot"
+  },
+  "result": {
+    "id": "beautify:lamp_light_bulb",
+    "count": 1
+  }
 }

--- a/src/main/resources/data/beautify/recipe/mangrove_blinds.json
+++ b/src/main/resources/data/beautify/recipe/mangrove_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:mangrove_slab"
-        }
-    },
-    "result": {
-        "id": "beautify:mangrove_blinds",
-        "count": 1
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:mangrove_slab"
+  },
+  "result": {
+    "id": "beautify:mangrove_blinds",
+    "count": 1
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/mangrove_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/mangrove_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:mangrove_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:mangrove_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:mangrove_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:mangrove_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/mangrove_trellis.json
+++ b/src/main/resources/data/beautify/recipe/mangrove_trellis.json
@@ -1,21 +1,17 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/ /",
-        " O ",
-        "/ /"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "O": {
-            "item": "minecraft:mangrove_log"
-        }
-    },
-    "result": {
-        "id": "beautify:mangrove_trellis",
-        "count": 4
-    },
-    "group": "trellis"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " O ",
+    "/ /"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "O": "minecraft:mangrove_log"
+  },
+  "result": {
+    "id": "beautify:mangrove_trellis",
+    "count": 4
+  },
+  "group": "trellis"
 }

--- a/src/main/resources/data/beautify/recipe/oak_blinds.json
+++ b/src/main/resources/data/beautify/recipe/oak_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:oak_slab"
-        }
-    },
-    "result": {
-        "id": "beautify:oak_blinds",
-        "count": 1
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:oak_slab"
+  },
+  "result": {
+    "id": "beautify:oak_blinds",
+    "count": 1
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/oak_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/oak_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:oak_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:oak_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:oak_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:oak_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/oak_trellis.json
+++ b/src/main/resources/data/beautify/recipe/oak_trellis.json
@@ -1,21 +1,17 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/ /",
-        " O ",
-        "/ /"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "O": {
-            "item": "minecraft:oak_log"
-        }
-    },
-    "result": {
-        "id": "beautify:oak_trellis",
-        "count": 4
-    },
-    "group": "trellis"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " O ",
+    "/ /"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "O": "minecraft:oak_log"
+  },
+  "result": {
+    "id": "beautify:oak_trellis",
+    "count": 4
+  },
+  "group": "trellis"
 }

--- a/src/main/resources/data/beautify/recipe/quartz_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/quartz_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:quartz_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:quartz_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:quartz_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:quartz_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/rope.json
+++ b/src/main/resources/data/beautify/recipe/rope.json
@@ -1,17 +1,15 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "#",
-        "#",
-        "#"
-    ],
-    "key": {
-        "#": {
-            "item": "minecraft:string"
-        }
-    },
-    "result": {
-        "id": "beautify:rope",
-        "count": 1
-    }
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": "minecraft:string"
+  },
+  "result": {
+    "id": "beautify:rope",
+    "count": 1
+  }
 }

--- a/src/main/resources/data/beautify/recipe/spruce_blinds.json
+++ b/src/main/resources/data/beautify/recipe/spruce_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:spruce_slab"
-        }
-    },
-    "result": {
-        "id": "beautify:spruce_blinds",
-        "count": 1
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:spruce_slab"
+  },
+  "result": {
+    "id": "beautify:spruce_blinds",
+    "count": 1
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/spruce_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/spruce_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:spruce_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:spruce_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:spruce_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:spruce_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/spruce_trellis.json
+++ b/src/main/resources/data/beautify/recipe/spruce_trellis.json
@@ -1,21 +1,17 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/ /",
-        " O ",
-        "/ /"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "O": {
-            "item": "minecraft:spruce_log"
-        }
-    },
-    "result": {
-        "id": "beautify:spruce_trellis",
-        "count": 4
-    },
-    "group": "trellis"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " O ",
+    "/ /"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "O": "minecraft:spruce_log"
+  },
+  "result": {
+    "id": "beautify:spruce_trellis",
+    "count": 4
+  },
+  "group": "trellis"
 }

--- a/src/main/resources/data/beautify/recipe/warped_blinds.json
+++ b/src/main/resources/data/beautify/recipe/warped_blinds.json
@@ -1,20 +1,16 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/_/",
-        "/_/"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "_": {
-            "item": "minecraft:warped_slab"
-        }
-    },
-    "result": {
-        "id": "beautify:warped_blinds",
-        "count": 1
-    },
-    "group": "blinds"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/_/",
+    "/_/"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "_": "minecraft:warped_slab"
+  },
+  "result": {
+    "id": "beautify:warped_blinds",
+    "count": 1
+  },
+  "group": "blinds"
 }

--- a/src/main/resources/data/beautify/recipe/warped_picture_frame.json
+++ b/src/main/resources/data/beautify/recipe/warped_picture_frame.json
@@ -1,24 +1,18 @@
 {
-	"type": "minecraft:crafting_shaped",
-	"pattern": [
-		" _ ",
-		" W ",
-		" _/"
-	],
-	"key": {
-		"_": {
-			"item": "minecraft:warped_slab"
-		},
-		"W": {
-			"item": "minecraft:white_wool"
-		},
-		"/": {
-			"item": "minecraft:stick"
-		}
-	},
-	"result": {
-		"id": "beautify:warped_picture_frame",
-		"count": 1
-	},
-	"group": "frames"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " _ ",
+    " W ",
+    " _/"
+  ],
+  "key": {
+    "_": "minecraft:warped_slab",
+    "W": "minecraft:white_wool",
+    "/": "minecraft:stick"
+  },
+  "result": {
+    "id": "beautify:warped_picture_frame",
+    "count": 1
+  },
+  "group": "frames"
 }

--- a/src/main/resources/data/beautify/recipe/warped_trellis.json
+++ b/src/main/resources/data/beautify/recipe/warped_trellis.json
@@ -1,21 +1,17 @@
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern": [
-        "/ /",
-        " O ",
-        "/ /"
-    ],
-    "key": {
-        "/": {
-            "item": "minecraft:stick"
-        },
-        "O": {
-            "item": "minecraft:warped_stem"
-        }
-    },
-    "result": {
-        "id": "beautify:warped_trellis",
-        "count": 4
-    },
-    "group": "trellis"
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " O ",
+    "/ /"
+  ],
+  "key": {
+    "/": "minecraft:stick",
+    "O": "minecraft:warped_stem"
+  },
+  "result": {
+    "id": "beautify:warped_trellis",
+    "count": 4
+  },
+  "group": "trellis"
 }


### PR DESCRIPTION
Changed recipes according to work in 1.21.2+
Below is an exemple for a shaped craft but it's the same for all kinds of crafts, you just need to replace `key` by the appropriate keyword (i.e. `ingredients` for shapeless crafts).

Before
```json
"key" : {
    "#": {
        "item": "minecraft:stick"
    },
    "P": [
        {
            "tag": "minecraft:planks"
        }
    ]
}
```

Now
```json
"key" : {
    "#": "minecraft:stick",
    "P": "#minecraft:planks"
}
```